### PR TITLE
Fix effect preloading and gib despawning

### DIFF
--- a/src/gameplay/explosion/assets.rs
+++ b/src/gameplay/explosion/assets.rs
@@ -14,7 +14,7 @@ pub(super) fn plugin(app: &mut App) {
 
 #[derive(Resource, Asset, Clone, Reflect)]
 #[reflect(Resource)]
-pub(crate) struct ExplosionAssets {
+pub struct ExplosionAssets {
     #[dependency]
     pub(crate) prop_explosion_sfx: ShuffleBag<Handle<AudioSource>>,
     pub(crate) prop_explosion_vfx: Handle<EffectAsset>,

--- a/src/gameplay/explosion/mod.rs
+++ b/src/gameplay/explosion/mod.rs
@@ -1,4 +1,4 @@
-mod assets;
+pub(crate) mod assets;
 pub(crate) mod effects;
 
 use avian3d::prelude::*;

--- a/src/gameplay/npc/lifecycle.rs
+++ b/src/gameplay/npc/lifecycle.rs
@@ -16,6 +16,7 @@ use crate::{
         health::{OnDamage, OnDeath},
         npc::{ai_state::AiState, assets::NpcAssets, stats::NpcStats},
     },
+    screens::Screen,
     third_party::avian3d::CollisionLayer,
 };
 
@@ -69,6 +70,7 @@ fn on_enemy_death(
                         [CollisionLayer::Default],
                     )),
                 DespawnAfter::new(Duration::from_secs(10)),
+                StateScoped(Screen::Gameplay),
             ))
             .observe(remove_shadow_interactions);
     }

--- a/src/screens/loading/shader_compilation.rs
+++ b/src/screens/loading/shader_compilation.rs
@@ -2,10 +2,13 @@
 //! This reduces stuttering, especially for audio on Wasm.
 
 use bevy::prelude::*;
+use bevy_hanabi::ParticleEffect;
 #[cfg(feature = "hot_patch")]
 use bevy_simple_subsecond_system::hot;
 
 use crate::{
+    gameplay::explosion::assets::ExplosionAssets,
+    platform_support::is_webgpu_or_native,
     shader_compilation::{LoadedPipelineCount, all_pipelines_loaded, spawn_shader_compilation_map},
     theme::{palette::SCREEN_BACKGROUND, prelude::*},
 };
@@ -18,6 +21,7 @@ pub(super) fn plugin(app: &mut App) {
         (
             spawn_or_skip_shader_compilation_loading_screen,
             spawn_shader_compilation_map,
+            setup_particle_effects,
         ),
     );
 
@@ -49,6 +53,23 @@ fn spawn_or_skip_shader_compilation_loading_screen(
         BackgroundColor(SCREEN_BACKGROUND),
         StateScoped(LoadingScreen::Shaders),
         children![(widget::label("Compiling shaders..."), LoadingShadersLabel)],
+    ));
+}
+
+fn setup_particle_effects(mut commands: Commands, explosion_assets: Res<ExplosionAssets>) {
+    if !is_webgpu_or_native() {
+        // Skip particle effects setup if Hanabi is not supported.
+        return;
+    }
+
+    // Spawn the particle effects for shader compilation.
+    commands.spawn((
+        StateScoped(LoadingScreen::Shaders),
+        ParticleEffect::new(explosion_assets.prop_explosion_vfx.clone()),
+    ));
+    commands.spawn((
+        StateScoped(LoadingScreen::Shaders),
+        ParticleEffect::new(explosion_assets.enemy_explosion_vfx.clone()),
     ));
 }
 


### PR DESCRIPTION
- Preload Hanabi particle effects in the shader compilation screen
- Make gibs state-scoped so that they're despawned when you quit to title